### PR TITLE
Add VerdeDesk - tax tool for freelancers in Portugal

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [VerdeDesk](https://verdedesk.vercel.app) – English-friendly tax compliance tool for freelancers in Portugal. Simplifies green receipts (recibos verdes), IRS declarations, and quarterly payments.
 
 ## Financial Data & APIs
 


### PR DESCRIPTION
VerdeDesk (https://verdedesk.vercel.app) is an English-language tax compliance tool helping freelancers and digital nomads in Portugal issue green receipts, track income, and stay compliant with Portuguese tax law. It fits well in the Accounting & Reporting section of this list.