### PR TITLE
Add KeepRule - AI investment principles platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [YNAB](https://www.youneedabudget.com/) – Zero-based budgeting software.
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
+- [KeepRule](https://keeprule.com) – AI-powered investment principles platform. Learn from Buffett, Munger, and other masters with AI chat mentors.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
 
 ## Corporate Finance


### PR DESCRIPTION
Adding [KeepRule](https://keeprule.com) to the **Personal Finance** section.

KeepRule is an AI-powered investment principles platform that helps investors learn from masters like Warren Buffett and Charlie Munger through AI chat mentors and scenario-based decision making.

- Link is active and points to a legitimate resource
- Description is clear and objective
- Placed alphabetically in the Personal Finance section