### PR TITLE
Add NationalTaxTools - Free tax policy calculators

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [Mint](https://mint.intuit.com/) – Personal budgeting and expense tracking platform.
 - [YNAB](https://www.youneedabudget.com/) – Zero-based budgeting software.
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
+- [NationalTaxTools](https://nationaltaxtools.com) - Free, no-login tax calculators for understanding how federal tax policies like No Tax on Tips, No Tax on Overtime, and the SALT Cap affect personal income. Built by an IRS Authorized e-File Provider.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
 


### PR DESCRIPTION
Added NationalTaxTools.com to the tax/personal finance tools section. Free, no-login interactive tax calculators covering No Tax on Tips, No Tax on Overtime, SALT $40K Cap, and Auto Loan Interest Deduction. All content built by a PTIN-holding, IRS Authorized e-File Provider with 22+ years of experience. No ads, no data collection, no registration required.

## Thank you for your contribution!

Please make sure your pull request follows our guidelines:

### Checklist

- [x] My submission is useful and relevant to this list.
- [ ] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [x] I have not added a link to my own project if it's not notable or widely used.

### Description of the Change

<!-- Describe why you are adding this resource and why it's Awesome -->

### Additional Notes (if any)

<!-- Optional: Any notes for reviewers -->
