### PR TITLE
Add 13F Insight under Modeling, Analytics & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 - [R Finance Packages](https://cran.r-project.org/web/views/Finance.html) – Statistical and financial modeling tools.
 - [MATLAB Finance Toolbox](https://www.mathworks.com/products/finance.html) – Quantitative finance and risk modeling tools.
 - [Power BI](https://powerbi.microsoft.com/) – Financial dashboards and reporting.
+- [13F Insight](https://13finsight.com/) – Institutional holdings research platform for analyzing SEC 13F filings, manager portfolio changes, and conviction shifts.
 
 ## Regulation & Compliance
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@
 - [R Finance Packages](https://cran.r-project.org/web/views/Finance.html) – Statistical and financial modeling tools.
 - [MATLAB Finance Toolbox](https://www.mathworks.com/products/finance.html) – Quantitative finance and risk modeling tools.
 - [Power BI](https://powerbi.microsoft.com/) – Financial dashboards and reporting.
-- [13F Insight](https://13finsight.com/) – Institutional holdings research platform for analyzing SEC 13F filings, manager portfolio changes, and conviction shifts.
+- [13F Insight](https://13finsight.com/?utm_source=github&utm_medium=referral&utm_campaign=seo_outreach_20260414&utm_content=brandonhimpfen_awesome-finance) – Institutional holdings research platform for analyzing SEC 13F filings, manager portfolio changes, and conviction shifts.
 
 ## Regulation & Compliance
 


### PR DESCRIPTION
This resubmits [13F Insight](https://13finsight.com/?utm_source=github&utm_medium=referral&utm_campaign=seo_outreach_20260414&utm_content=brandonhimpfen_awesome-finance) in the category you suggested on the earlier PR.

Why this fit is better:
- It is an investment research / data analysis platform rather than a regulation-compliance resource
- It helps investors analyze SEC 13F filings, manager portfolio changes, and conviction shifts
- That makes it a better match for **Modeling, Analytics & Tools** than **Regulation & Compliance**

Added as a single concise entry only.
