### PR TITLE
Add AI Invoice Maker (free invoice generator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [AI Invoice Maker](https://ainvoicemaker.com/) – Free invoice generator with AI-powered payment reminders for freelancers and small businesses; 50+ currencies, no signup, no watermark.
 
 ## Financial Data & APIs
 


### PR DESCRIPTION
Adds [AI Invoice Maker](https://ainvoicemaker.com/) under **Accounting & Reporting** alongside QuickBooks and FreshBooks.

### Why it fits
- Same category as the existing FreshBooks / QuickBooks entries (cloud-hosted invoicing/accounting tools for small businesses)
- Differentiates by being completely free with no signup, no watermark — useful for freelancers and solo operators evaluating tools without a trial flow
- AI-assisted payment reminders is a feature not present in the current Accounting entries

### Entry
```
- [AI Invoice Maker](https://ainvoicemaker.com/) – Free invoice generator with AI-powered payment reminders for freelancers and small businesses; 50+ currencies, no signup, no watermark.
```

Happy to revise wording or move section if a different placement fits better.