### PR TITLE
Add bigtech-ai-stakes to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Quandl / Nasdaq Data Link](https://data.nasdaq.com/) – Financial and economic datasets.
 - [IEX Cloud](https://iexcloud.io/) – Market data APIs for developers.
 - [FRED](https://fred.stlouisfed.org/) – Federal Reserve economic and financial data.
+- [bigtech-ai-stakes](https://github.com/YichengYang-Ethan/bigtech-ai-stakes) – Open dataset of U.S. public-company equity stakes in Anthropic and OpenAI, sourced from primary SEC filings, court records, and press releases. Confidence-tagged.
 
 ## Modeling, Analytics & Tools
 


### PR DESCRIPTION
## What

Adds [bigtech-ai-stakes](https://github.com/YichengYang-Ethan/bigtech-ai-stakes)
to the **Financial Data & APIs** section.

## Why it fits

`bigtech-ai-stakes` is an open dataset that aggregates publicly disclosed
equity stakes held by U.S. public companies (Microsoft, Alphabet, Amazon,
NVIDIA, Salesforce) in Anthropic and OpenAI. Sources are primary documents:
SEC 10-K / 10-Q / 8-K filings, U.S. federal court records, and company press
releases. Each row carries an explicit confidence flag — `V` (verified by
primary source), `P` (probable, multi-source secondary), `S` (speculative,
single source).

The repo packages:
- A headline ownership table with full source attribution
- An auto-generated panel from 55 real SEC 10-K / 10-Q filings
- A curated funding-round catalog (Anthropic Series C–G, OpenAI 2019–2026)
- v0.1.0 release with `CITATION.cff` for dataset citation

License: code MIT, data CC-BY-4.0. Documentation and methodology are in
`docs/`. The repo has CI, tests, and an issue template for data corrections.

## Pull Request Checklist

- [x] The link is active and points to a legitimate resource
- [x] The resource is valuable, trustworthy, and relevant
- [x] The resource fits the scope and category of the list (Financial Data & APIs)
- [x] Description is clear and objective
- [x] Single source, single addition