### PR TITLE
Add Levyio (tax calc) + Amortio (mortgage calc) to Personal Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [Levyio](https://levyio.com/) – Free US tax calculators by state and city, including income, property, and sales tax with 2026 IRS-aligned methodology.
+- [Amortio](https://www.amortio.com/) – Free mortgage calculators using Freddie Mac PMMS rate data, with PITI breakdown, FHA/VA/USDA loan eligibility, and refinance analysis.
 
 ## Corporate Finance
 


### PR DESCRIPTION
Two free US-focused finance calculators for the Personal Finance section:

- **Levyio** — Free US tax calculators (income, property, sales) by state and city. 2026 IRS-aligned methodology citing BLS, IRS, Tax Foundation, and state revenue departments. https://levyio.com/

- **Amortio** — Free mortgage calculators using Freddie Mac PMMS weekly rate data. PITI breakdown, FHA/VA/USDA loan eligibility analysis, refinance break-even calculations. Cites Freddie Mac, FRED, FHFA, CFPB, HUD. https://www.amortio.com/

Both free, no signup required, aligned with US tax/mortgage regulations.