### PR TITLE
Add Adanos finance data resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 
 ## Financial Data & APIs
 
+- [Adanos](https://adanos.org/) – Market sentiment API for stocks and crypto, using Reddit, X / FinTwit, financial news, and Polymarket signals.
 - [Yahoo Finance](https://finance.yahoo.com/) – Market data, quotes, and financial news.
 - [Alpha Vantage](https://www.alphavantage.co/) – Free APIs for stock, forex, and crypto data.
 - [Quandl / Nasdaq Data Link](https://data.nasdaq.com/) – Financial and economic datasets.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 
 ## Financial Data & APIs
 
-- [Adanos](https://adanos.org/) – Market sentiment API for stocks and crypto, using Reddit, X / FinTwit, financial news, and Polymarket signals.
+- [Adanos](https://api.adanos.org/docs) – Market sentiment API for stocks and crypto, using Reddit, X / FinTwit, financial news, and Polymarket signals.
 - [Yahoo Finance](https://finance.yahoo.com/) – Market data, quotes, and financial news.
 - [Alpha Vantage](https://www.alphavantage.co/) – Free APIs for stock, forex, and crypto data.
 - [Quandl / Nasdaq Data Link](https://data.nasdaq.com/) – Financial and economic datasets.


### PR DESCRIPTION
## Summary

- Add Adanos to the `Financial Data & APIs` section.
- Link the README entry directly to the public API documentation: https://api.adanos.org/docs
- Keep the README change to a single neutral resource entry.
- Re-submit after the feedback on #26 with additional context and public documentation links.

## Disclosure and project context

This is an affiliated submission. I am submitting this on behalf of / in connection with Adanos Software GmbH, the organization behind Adanos.

Adanos is a production REST API and web resource for market sentiment and attention data. It covers stocks and crypto using signals from Reddit, X / FinTwit, financial news, and Polymarket. The public website identifies Adanos Software GmbH and provides contact, terms, privacy, pricing, API-key registration, public ranking pages, endpoint pages, and machine-readable API references.

## Publicly available functionality

Currently public / production-ready:

- Public API docs: https://api.adanos.org/docs
- Self-service API-key registration: https://adanos.org/register
- Pricing and usage limits: https://adanos.org/pricing
- API overview and product page: https://adanos.org/
- Source-specific endpoint pages:
  - Reddit stock sentiment: https://adanos.org/reddit-stock-sentiment
  - Reddit crypto sentiment: https://adanos.org/reddit-crypto-sentiment
  - X stock sentiment: https://adanos.org/x-stock-sentiment
  - Stock news sentiment: https://adanos.org/stock-news-sentiment
  - Polymarket stock sentiment: https://adanos.org/polymarket-stock-sentiment
- Public ranking pages:
  - Reddit top stocks: https://adanos.org/reddit-top-100-stocks
  - Reddit top crypto: https://adanos.org/reddit-top-100-crypto
  - X top stocks: https://adanos.org/x-top-100-stocks
- Developer references:
  - Python SDK: https://github.com/adanos-software/adanos-python-sdk
  - TypeScript SDK: https://github.com/adanos-software/adanos-ts-sdk
  - CLI: https://github.com/adanos-software/adanos-cli
  - OpenAPI schema: https://api.adanos.org/openapi.json
  - LLM/API overview: https://api.adanos.org/llms.txt
  - Full LLM/API reference: https://api.adanos.org/llms-full.txt
  - Public Postman docs: https://documenter.getpostman.com/view/46550266/2sBXqJMMMi

## Data sources and methodology transparency

The API aggregates market attention and directional sentiment signals from Reddit, X / FinTwit, financial news, and Polymarket. The public API documentation describes the main response concepts: `buzz_score`, `trend`, `sentiment_score`, bullish/bearish percentages, trend history, activity fields, and platform-specific coverage fields. The OpenAPI schema and LLM reference document endpoint paths, query parameters, response fields, and error behavior.

## Checklist

- [x] The submission is relevant to the finance data/API section.
- [x] The README entry is short and neutral.
- [x] The README link points directly to public API documentation.
- [x] The link is public and working.
- [x] This is an affiliated submission and the affiliation is disclosed here.
- [x] Public documentation, onboarding, SDKs, CLI, API schema, and sample-oriented references are linked above.

## Checks run

- `git diff --check`
- `python3 .github/scripts/detect_duplicate_links.py README.md`
- GET status check for `https://api.adanos.org/docs` returned 200
- HTTP status checks for `https://adanos.org/`, `https://adanos.org/llms.txt`, `https://api.adanos.org/openapi.json`, and the public Postman documentation URL

Note: I also inspected `CONTRIBUTING.md` and kept this PR intentionally narrow because the previous PR did not include enough project context for evaluation.
