### PR TITLE
Add Sharpe to financial data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Quandl / Nasdaq Data Link](https://data.nasdaq.com/) – Financial and economic datasets.
 - [IEX Cloud](https://iexcloud.io/) – Market data APIs for developers.
 - [FRED](https://fred.stlouisfed.org/) – Federal Reserve economic and financial data.
+- [Sharpe](https://www.sharpe.ai/docs/free-api) – Crypto market data API for funding rates, derivatives, arbitrage, narratives, exchange listings, and news.
 
 ## Modeling, Analytics & Tools
 


### PR DESCRIPTION
## Thank you for your contribution!

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows the quality and content standards.
- [x] I have not added multiple links to promote a single source.

### Description of the Change

Adds Sharpe to Financial Data & APIs. The entry links to the API docs and keeps the description focused on the data surface: crypto funding rates, derivatives, arbitrage, narratives, exchange listings, and news.

Website URL: https://www.sharpe.ai/docs/free-api
Validation: `git diff --check` passes.
Linear: SHA-153

### Additional Notes

Disclosure: I work on Sharpe.