### PR TITLE
Add Adanos finance data API entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 
 ## Financial Data & APIs
 
+- [Adanos](https://api.adanos.org/docs) – Market sentiment API for stocks and crypto, using Reddit, X / FinTwit, financial news, and Polymarket signals.
 - [Yahoo Finance](https://finance.yahoo.com/) – Market data, quotes, and financial news.
 - [Alpha Vantage](https://www.alphavantage.co/) – Free APIs for stock, forex, and crypto data.
 - [Quandl / Nasdaq Data Link](https://data.nasdaq.com/) – Financial and economic datasets.


### PR DESCRIPTION
## Summary

This replaces the closed #27 with only the final entry requested by the maintainer.

Added to **Financial Data & APIs**:

> [Adanos](https://api.adanos.org/docs) – Market sentiment API for stocks and crypto, using Reddit, X / FinTwit, financial news, and Polymarket signals.

## Notes

- References #27.
- This PR contains only the final intended change.

## Checks

- git diff --check