### PR TITLE
Add PDFExcel to Accounting & Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [PDFExcel](https://pdfexcel.ai/) – AI tool that converts PDFs (including scanned and photographed documents) into Excel, CSV, or Google Sheets for accountants and bookkeepers.
 
 ## Financial Data & APIs
 


### PR DESCRIPTION
PDFExcel (https://pdfexcel.ai) is an AI-powered tool that converts any PDF — including scanned and photographed documents — into clean Excel, CSV, or Google Sheets without templates. Its primary user base is bookkeepers, CPA firms, and accountants who need to extract data from bank statements, invoices, and 1099s.

It fits the Accounting & Reporting section alongside existing entries like QuickBooks and FreshBooks. I followed the section's formatting (dash bullet, en-dash separator, sentence-case description ending in a period) and placed the entry after FreshBooks, at the end of the tools cluster.

Happy to adjust the description or placement if needed.