### PR TITLE
Add digital product seller ledger sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [IFRS](https://www.ifrs.org/) – International Financial Reporting Standards.
 - [GAAP](https://www.fasb.org/) – U.S. Generally Accepted Accounting Principles.
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
+- [Digital Product Seller Ledger Sample](https://github.com/Ronnie2025/xianyu-virtual-product-ledger-sample) – MIT-licensed CSV worksheet for small digital product sellers to record revenue, platform fees, product costs, after-sales issues, refund reasons, and gross margin.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [IFRS](https://www.ifrs.org/) – International Financial Reporting Standards.
 - [GAAP](https://www.fasb.org/) – U.S. Generally Accepted Accounting Principles.
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
-- [Digital Product Seller Ledger Sample](https://github.com/Ronnie2025/xianyu-virtual-product-ledger-sample) – MIT-licensed CSV worksheet for small digital product sellers to record revenue, platform fees, product costs, after-sales issues, refund reasons, and gross margin.
+- [Digital Product Seller Ledger Sample](https://github.com/Ronnie2025/xianyu-virtual-product-ledger-sample) – MIT-licensed Excel/CSV worksheet for small digital product sellers to record revenue, platform fees, product costs, after-sales issues, refund reasons, and gross margin.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
 


### PR DESCRIPTION
## Summary
- Adds a free MIT-licensed CSV worksheet for small digital product sellers to the Accounting & Reporting section.
- The worksheet helps record revenue, platform fees, product costs, after-sales issues, refund reasons, and gross margin.

## Validation
- git diff --check
- Verified the GitHub sample repository returns HTTP 200.
- Verified the sample landing page returns HTTP 200 and includes the trial guide.