### PR TITLE
Add ReceiptEdit US Sales Tax 2026 to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Quandl / Nasdaq Data Link](https://data.nasdaq.com/) – Financial and economic datasets.
 - [IEX Cloud](https://iexcloud.io/) – Market data APIs for developers.
 - [FRED](https://fred.stlouisfed.org/) – Federal Reserve economic and financial data.
+- [ReceiptEdit US Sales Tax 2026](https://github.com/receiptedit/us-sales-tax-2026) – Free MIT-licensed dataset and REST API of 2026 US state sales tax rates, lodging taxes, and grocery rules for all 50 states.
 
 ## Modeling, Analytics & Tools
 


### PR DESCRIPTION
Adding the ReceiptEdit US Sales Tax 2026 dataset to the Financial Data & APIs section.

Free MIT-licensed dataset covering 2026 US state sales tax rates for all 50 states, including:
- Statewide sales tax rate
- Average combined state + local rate
- Lodging-specific taxes (TOT, occupancy, tourism)
- Grocery taxation rules
- Top 5 cities per state

Available as CSV, JSON, and a free public REST API.

Dataset repo: https://github.com/receiptedit/us-sales-tax-2026
API: https://receiptedit.com/api/sales-tax
License: MIT (with attribution)