### PR TITLE
Add Find My Moat

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 ## Modeling, Analytics & Tools
 
 - [Excel for Finance](https://support.microsoft.com/excel) – Core modeling tool for finance professionals.
+- [Find My Moat](https://www.findmymoat.com/) - Directory for comparing investment research tools, stock analysis platforms, screeners, and portfolio trackers.
 - [Python for Finance](https://www.python.org/) – Programming ecosystem for financial analysis.
 - [R Finance Packages](https://cran.r-project.org/web/views/Finance.html) – Statistical and financial modeling tools.
 - [MATLAB Finance Toolbox](https://www.mathworks.com/products/finance.html) – Quantitative finance and risk modeling tools.


### PR DESCRIPTION
## Summary

Adds Find My Moat to Modeling, Analytics & Tools as a directory for comparing investment research tools, stock analysis platforms, screeners, and portfolio trackers.

## Validation

- Confirmed the URL returns HTTP 200.
- Checked the README for an existing Find My Moat entry; none was present.
- Ran duplicate-link detection; no duplicate resource URLs were introduced.
- The existing awesome-list lint script reports pre-existing README formatting errors unrelated to this change.