### PR TITLE
Add FilingFirehose Forensic — SEC filings risk-scoring API

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Quandl / Nasdaq Data Link](https://data.nasdaq.com/) – Financial and economic datasets.
 - [IEX Cloud](https://iexcloud.io/) – Market data APIs for developers.
 - [FRED](https://fred.stlouisfed.org/) – Federal Reserve economic and financial data.
+- [FilingFirehose Forensic](https://filingfirehose.com/forensic) – SEC filings risk-scoring API and per-ticker pages; surfaces bankruptcy, delisting, restatement, officer-departure, and dilution signals with verifiable EDGAR accession numbers.
 
 ## Modeling, Analytics & Tools
 


### PR DESCRIPTION
Adds [Forensic by FilingFirehose](https://filingfirehose.com/forensic) under **Financial Data & APIs**.

Forensic scores any US-listed ticker's last 3 years of SEC filings for bear-case risk signals — bankruptcy notices (Item 1.03), delisting notices (Item 3.01), restatements (Item 4.02), officer departures, and dilution (S-3, 424B5, ATM). Every flag includes the EDGAR accession number for verification.

Free per-ticker pages. API + monitoring on paid plans. Examples:
- High-risk: https://filingfirehose.com/forensic/SNBR (score 88)
- Low-risk: https://filingfirehose.com/forensic/NVDA (score 16)

Thanks for maintaining this list.