### PR TITLE
Add ClearCalc — free financial calculators (mortgage, retirement, debt payoff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [ClearCalc](https://getclearcalc.com/) – Free online financial calculators: mortgage, auto loan, compound interest, retirement, debt payoff, and savings — no signup required.
 
 ## Corporate Finance
 


### PR DESCRIPTION
## What

Adds **[ClearCalc](https://getclearcalc.com/)** to the Personal Finance section.

## Why

ClearCalc is a free, no-signup financial calculator suite covering the most common personal finance calculations:
- Mortgage & Refinance Calculator
- Auto Loan Calculator
- Compound Interest Calculator
- Debt Payoff Calculator (avalanche + snowball)
- Retirement Calculator
- Savings Goal Calculator

It's a clean, ad-supported static site — useful to anyone planning a major financial decision. Fits naturally alongside Mint, YNAB, NerdWallet, and Personal Capital in the Personal Finance section.