### PR TITLE
Add Acalcia (free no-signup money & tax calculators)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [Acalcia](https://acalcia.com/) – Free no-signup suite of in-browser money and tax calculators for US freelancers, online sellers, and creators (self-employment and quarterly tax, marketplace fees, pricing and margins, invoicing).
 
 ## Corporate Finance
 


### PR DESCRIPTION
Adds [Acalcia](https://acalcia.com) — a free, no-signup suite of in-browser money & tax calculators for freelancers, online sellers, and creators (self-employment & quarterly tax, marketplace/payment fees, freelance rates, pricing, invoicing).

- Follows this list's existing entry format
- Single addition, not a duplicate (searched the list)
- Static, privacy-friendly, runs entirely in the browser — no signup, no paywall

Disclosure: I'm the maker. Thanks for curating this list!