### PR TITLE
Add Personal Finance Whitepaper to Personal Finance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [Personal Finance Whitepaper](https://nontravis.github.io/personal-finance-whitepaper/) – Free, multilingual guide to building wealth with a 3-pillar Cashflow/Investment/Savings framework.
 
 ## Corporate Finance
 


### PR DESCRIPTION
Adds a resource to the Personal Finance section.

- **Resource**: [Personal Finance Whitepaper](https://nontravis.github.io/personal-finance-whitepaper/)
- **What it is**: A free, multilingual (6 languages) educational whitepaper teaching a simple 3-pillar personal finance framework — Cashflow, Investment, Savings.
- **Why it fits**: Same category as Bogleheads/NerdWallet — an educational personal-finance resource, not a promotional tool signup.

Checklist:
- [x] Link is active (verified 200 response)
- [x] Fits existing Personal Finance section scope
- [x] Description is short and objective
- [x] No duplicate/broken links
- [x] Single addition, not multi-link self-promotion