### PR TITLE
Add Threshold to Personal Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [Threshold](https://threshold-calculator.com/) – Free rent-vs-buy calculator comparing after-tax net worth over a chosen horizon, with house-hacking and tax-shield modeling.
 
 ## Corporate Finance
 


### PR DESCRIPTION
## Description

Adding Threshold to the Personal Finance section. It's a free rent vs buy calculator I built that compares after-tax net worth at the end of your time horizon rather than monthly payments. It handles the mortgage interest deduction properly (only the amount above the standard deduction actually saves you anything, which most calculators get wrong) and can model renting out part of the property. No signup, no ads, runs entirely in the browser.

## Checklist

- [x] Link is active and correct
- [x] Description is objective and concise
- [x] Not a duplicate: the list currently has no rent vs buy tool
- [x] I'm the author of the tool