### PR TITLE
Add LE TEEN College ROI Calculator to Personal Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Mint](https://mint.intuit.com/) – Personal budgeting and expense tracking platform.
 - [YNAB](https://www.youneedabudget.com/) – Zero-based budgeting software.
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
+- [LE TEEN College ROI Calculator](https://le-teen.com/worth-it) – Free calculator and rankings comparing lifetime return on investment across US colleges and majors, built on FREOPP, IPEDS, and BEA data.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
 


### PR DESCRIPTION
Adds a free personal-finance tool to the Personal Finance section: a college ROI calculator + rankings covering 29,700 US bachelor's programs (30-year net present value, resident vs non-resident pricing), built on public FREOPP, IPEDS, and BEA data. Free, no signup; the underlying dataset is open (CC BY 4.0, Zenodo DOI 10.5281/zenodo.21351603). Disclosure: I run this project.