### PR TITLE
Add TransactionLookup to Personal Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [TransactionLookup](https://transactionlookup.com/) – Free tool that identifies unknown bank and credit card charges from statement descriptors.
 
 ## Corporate Finance
 


### PR DESCRIPTION
Adds **TransactionLookup** to the Personal Finance section.

- **Link:** https://transactionlookup.com/
- **What it is:** a free consumer tool that identifies unknown bank and credit card charges by explaining confusing statement descriptors (e.g. `AMZN MKTP US`, `SQ *`).
- **Fit:** sits alongside the other consumer personal-finance tools already listed (Mint, NerdWallet). Free, no account required.

Follows CONTRIBUTING.md: single entry, existing `- [Name](URL) – Description.` format, active link, objective one-line description placed in the matching category.