### PR TITLE
Add DepthFeed prediction-market liquidity benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 ## Financial Data & APIs
 
 - [Adanos](https://api.adanos.org/docs) – Market sentiment API for stocks and crypto, using Reddit, X / FinTwit, financial news, and Polymarket signals.
+- [DepthFeed Prediction Market Liquidity Benchmark](https://depthfeed.com/arena/liquidity) – Open CC BY 4.0 order-book dataset with 34,560 lifecycle-aligned observations across Polymarket, Kalshi, Predict.fun via Binance Wallet, and Limitless.
 - [Eulerpool](https://eulerpool.com/financial-data-api) – Financial data API for stocks, ETFs, crypto, forex, bonds, and macroeconomic datasets.
 - [Yahoo Finance](https://finance.yahoo.com/) – Market data, quotes, and financial news.
 - [Alpha Vantage](https://www.alphavantage.co/) – Free APIs for stock, forex, and crypto data.


### PR DESCRIPTION
## Summary

Adds the DepthFeed Prediction Market Liquidity Benchmark to Financial Data & APIs.

## Why it meets the editorial criteria

- Relevant: a directly downloadable financial-market microstructure dataset.
- Documented: public methodology, limitations, findings, citation metadata, and release history.
- Reproducible: a dependency-free verifier checks the 34,560-row panel, SHA-256 checksum, headline metrics, and confidence intervals.
- Open: CC BY 4.0 data/research license and MIT verification code.
- Focused: one neutral entry and one canonical link, in the existing list format.

I searched the README and open/closed pull requests and found no duplicate. The canonical URL returns HTTP 200, and `git diff --check` passes.

Affiliation disclosure: I am submitting this dataset on behalf of the DepthFeed team.
