### PR TITLE
Add ml-quant-trading to Quantitative Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [QuantLib](https://www.quantlib.org/) – Open-source library for quantitative finance modeling.
 - [Zipline](https://www.zipline.io/) – Algorithmic trading library for backtesting strategies.
 - [Backtrader](https://www.backtrader.com/) – Python framework for trading strategy development.
+- [ml-quant-trading](https://github.com/initial-d/ml-quant-trading) – PyTorch research stack for multi-factor modeling, portfolio optimization, and reproducible backtesting.
 - [PyPortfolioOpt](https://pyportfolioopt.readthedocs.io/) – Portfolio optimization library.
 - [QSTrader](https://github.com/mhallsmoore/qstrader) – Event-driven backtesting engine.
 


### PR DESCRIPTION
Adds `ml-quant-trading` to the Quantitative Finance section.

The project is a maintained, documented PyTorch research stack covering multi-factor modeling, portfolio optimization, public-data validation, and reproducible backtesting. It has tagged releases, CI, tests, an MIT license, an accompanying arXiv paper, and explicit research-use limitations.

Checklist:

- active public link
- one objective description and one link
- existing Quantitative Finance category
- no duplicate entry
- README formatting preserved

Disclosure: I maintain the submitted project.