### PR TITLE
Add SmartBizCalc to Accounting & Reporting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [SmartBizCalc](https://www.smartbizcalc.com/) – 400+ free small business calculators covering payroll tax, break-even, S-corp savings, startup costs, business insurance, and contractor pricing.
 
 ## Financial Data & APIs
 


### PR DESCRIPTION
SmartBizCalc (https://www.smartbizcalc.com/) is a free collection of 400+ small business calculators covering payroll tax, break-even, S-corp vs LLC tax savings, startup costs, business insurance, contractor pricing, and more. It fits naturally alongside QuickBooks and FreshBooks in the Accounting & Reporting section as a practical financial calculation resource for small business owners and self-employed professionals.