### PR TITLE
Add Frifti to Personal Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [Frifti](https://www.frifti.com/) – Free 50-state unclaimed property search with a guided claim wizard.
 
 ## Corporate Finance
 


### PR DESCRIPTION
Adds [Frifti](https://www.frifti.com/), a free 50-state unclaimed property search tool with a guided claim wizard, to the Personal Finance section.

Unclaimed property/money search isn't currently represented in this list even though it's a common personal-finance task (old bank accounts, uncashed checks, insurance payouts, etc. held by state treasuries). Frifti is free to use, with no paid upsell, and walks users through filing the actual claim once they find a match rather than just linking out to a raw state database.

Single addition, alphabetically placed within the existing section, follows the format of neighboring entries.