### PR TITLE
Add Quant Sprint under Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Khan Academy Finance](https://www.khanacademy.org/economics-finance-domain) – Introductory finance and investing lessons.
 - [CFA Program Curriculum](https://www.cfainstitute.org/programs/cfa/curriculum) – Comprehensive investment education.
 - [Coursera Finance Courses](https://www.coursera.org/browse/business/finance) – University-backed finance programs.
+- [Quant Sprint](https://lambdia.com/play) – Free timed drill of quant trading interview questions on options, market making and probability.
 
 ### Guides
 - [Aswath Damodaran Valuation](https://pages.stern.nyu.edu/~adamodar/) – Valuation theory and datasets.


### PR DESCRIPTION
Adds one entry under Learning Resources: [Quant Sprint](https://lambdia.com/play).

A free timed drill for quant trading interview questions. A run lasts 72 seconds, right answers buy time back and wrong ones cost four. Questions are drawn rather than written, and cover options and the Greeks, two sided quoting, probability, brainteasers and mental arithmetic.

I put it under Tutorials since that is where the free learning sites already sit. Happy to move it if you would rather add a Practice subsection.

Disclosure: I built it. No account, no install.