### PR TITLE
Add AxionQuant to Financial Data and APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 ## Financial Data & APIs
 
 - [Adanos](https://api.adanos.org/docs) – Market sentiment API for stocks and crypto, using Reddit, X / FinTwit, financial news, and Polymarket signals.
+- [AxionQuant](https://axionquant.com/) – Unified financial data API for market prices, fundamentals, disclosures, macroeconomic, and alternative data, with a Python SDK ([axionquant-sdk](https://pypi.org/project/axionquant-sdk/)).
 - [Eulerpool](https://eulerpool.com/financial-data-api) – Financial data API for stocks, ETFs, crypto, forex, bonds, and macroeconomic datasets.
 - [Yahoo Finance](https://finance.yahoo.com/) – Market data, quotes, and financial news.
 - [Alpha Vantage](https://www.alphavantage.co/) – Free APIs for stock, forex, and crypto data.


### PR DESCRIPTION
Adds **AxionQuant** to the *Financial Data & APIs* section per `CONTRIBUTING.md`.

**AxionQuant** is a unified financial data API covering market prices, fundamentals, disclosures, macroeconomic, and alternative data - designed for long-horizon research and quantitative modeling. Includes a native Python SDK (`axionquant-sdk`).

## Checklist

- [x] The link is active and points to a legitimate resource.
- [x] The resource is valuable, trustworthy, and relevant.
- [x] The resource fits the scope and category of the list.
- [x] Descriptions are clear and objective.
- [x] The list remains alphabetically sorted (if applicable).
- [x] I have not added multiple links to promote a single source.

**Links:**
- Site: https://axionquant.com/
- SDK: https://pypi.org/project/axionquant-sdk/