### PR TITLE
Add Toolkit Labs Invoice to Accounting & Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [Toolkit Labs Invoice](https://ytinumoc.github.io/toolkitlabs-invoice/) – Free browser invoice/receipt generator (print or save as PDF, no account). [Commercial license (EUR 249)](https://buy.stripe.com/bJeeVea187TScZwb095Ne0k?client_reference_id=awesome-finance-v1) for white-label PDFs, batch CLI, and templates. Open source.
 
 ## Financial Data & APIs
 


### PR DESCRIPTION
Adds [Toolkit Labs Invoice](https://github.com/YtinuMoc/toolkitlabs-invoice) under Accounting & Reporting.

- Free browser invoice/receipt PDF generator (no account)
- Commercial license (EUR 249): white-label, 6 templates, unlimited batch CLI
- One-time purchase alternative to subscription invoicing tools like FreshBooks/QuickBooks

Demo: https://ytinumoc.github.io/toolkitlabs-invoice/

Made with [Cursor](https://cursor.com)