### PR TITLE
Add PlainSums to Personal Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [PlainSums](https://www.plainsums.com/) – Free personal finance calculators for mortgages, loans, savings, and retirement with itemized estimates and visible assumptions.
 
 ## Corporate Finance
 


### PR DESCRIPTION
## Summary
Adds [PlainSums](https://www.plainsums.com/) under **Personal Finance**.

PlainSums is a free, no-sign-up suite of personal finance calculators (mortgage, loans, savings, retirement, and take-home pay) that show itemized estimates and visible assumptions.

## Checklist
- [x] Link is active and points to a legitimate resource
- [x] Resource is free, relevant, and fits Personal Finance
- [x] Description is short and objective (matches list style)
- [x] Single addition only; no duplicates
- [x] Follows CONTRIBUTING.md