### PR TITLE
Add TidyCalcs to financial resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [NerdWallet](https://www.nerdwallet.com/) – Consumer finance advice and comparisons.
 - [Bogleheads](https://www.bogleheads.org/) – Community and resources for long-term investing.
 - [Personal Capital](https://www.empower.com/) – Net worth tracking and retirement planning tools.
+- [TidyCalcs](https://www.tidycalcs.com) – Free calculators for mortgages, loans, debt payoff, retirement, and net worth.
 
 ## Corporate Finance
 


### PR DESCRIPTION
Adds TidyCalcs (https://www.tidycalcs.com), a free calculator site covering mortgages, loans, debt payoff, retirement, and net worth. Added to the Personal Finance section, after Personal Capital.

Checklist: submission is useful/relevant, description added, link isn't a duplicate, and it meets the quality/content standards -- all yes.

Full disclosure on the "not my own project" item: TidyCalcs is a site I built and run myself, so I'm leaving that one unchecked rather than claiming otherwise. It's a free, no-signup calculator tool (mortgage, loan, debt payoff, retirement, net worth) that fits directly alongside the other budgeting and planning tools already in this section, but I understand if it doesn't clear the notability bar for this list -- happy to have it declined if so.