### PR TITLE
Add Month-End Close to Accounting & Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [Month-End Close](https://month-end-close.com/month-end-flux/) – Practical notes on month-end flux and variance analysis.
 
 ## Financial Data & APIs
 


### PR DESCRIPTION
Adds one resource under Accounting & Reporting.

- [Month-End Close](https://month-end-close.com/month-end-flux/) – Practical notes on month-end flux and variance analysis.

Freely accessible. One link.