### PR TITLE
Add SmartBizCalc to Accounting & Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [SmartBizCalc](https://www.smartbizcalc.com/) – 400+ free small business calculators covering payroll tax, break-even, S-corp savings, startup costs, business insurance, and contractor pricing.
 
 ## Financial Data & APIs
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [XBRL](https://www.xbrl.org/) – Standard for digital financial reporting.
 - [QuickBooks](https://quickbooks.intuit.com/) – Accounting software for businesses.
 - [FreshBooks](https://www.freshbooks.com/) – Cloud accounting for small businesses.
+- [SmartBizCalc](https://smartbizcalc.com/) – Free small business calculators covering tax, insurance, break-even, payroll, loan, and contractor pricing with 530+ tools.
 - [SmartBizCalc](https://www.smartbizcalc.com/) – 400+ free small business calculators covering payroll tax, break-even, S-corp savings, startup costs, business insurance, and contractor pricing.
 
 ## Financial Data & APIs


### PR DESCRIPTION
SmartBizCalc is a free suite of 530+ small business calculators covering tax (self-employment, payroll, LLC vs S-corp, quarterly estimated), insurance (workers comp, general liability, commercial property), break-even, loan analysis, contractor pricing, and more. Fits well alongside QuickBooks and FreshBooks in the Accounting & Reporting section for practitioners and business owners who need quick financial calculations.